### PR TITLE
docs: remove specific mutation testing percentages from claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ it('should calculate tax', () => {
   expect(typeof result).toBe('number'); // ✅ Passes - 100% coverage!
 });
 
-// Our 99.04% mutation testing requirement catches this
+// Our mutation testing with Stryker catches this
 // When logic is mutated, the test still passes, revealing it's fake
 ```
 
@@ -54,7 +54,7 @@ const config = ConfigSchema.parse(process.env); // ✅ Validation required
 
 - **Human pace**: Think → Code → Test → Review (minutes to hours)
 - **AI pace**: Generate → Validate → Iterate (seconds)
-- **Our solution**: Sub-5-second quality gates that match AI's speed
+- **Our solution**: Fast quality gates optimized for AI's rapid iteration
 
 This template implements **constraint-based development** where quality comes from systematic guardrails, not developer experience.
 
@@ -161,7 +161,7 @@ ai-fastify-template/
 | **Security scanning**       | GitLeaks + audit-ci                  | AI might commit secrets without realizing                            | Manual review sufficient  |
 | **Guard against spaghetti** | dependency-cruiser                   | AI creates circular dependencies without understanding               | Relies on code review     |
 | **High-trust tests**        | Vitest + Coverage                    | Basic foundation for testing                                         | Same usage                |
-| **Mutation testing**        | Stryker (99.04% score)               | **Catches AI's "fake tests" that achieve coverage but test nothing** | Rarely used (expensive)   |
+| **Mutation testing**        | Stryker (high standards)             | **Catches AI's "fake tests" that achieve coverage but test nothing** | Rarely used (expensive)   |
 | **Task caching**            | pnpm workspaces + TurboRepo          | Sub-5-second feedback for AI's rapid iteration                       | Same usage                |
 
 ## Available Scripts
@@ -196,7 +196,7 @@ pnpm setup:gitleaks   # Install/update GitLeaks scanner
 
 # Advanced Quality Gates
 pnpm lint             # Code formatting and linting (ESLint + Prettier)
-pnpm test:mutation    # Run mutation tests (99.04% score)
+pnpm test:mutation    # Run mutation tests with quality validation
 ```
 
 ## Workspace Structure
@@ -272,7 +272,7 @@ pnpm install
 - **Strict TypeScript** - No `any` types, comprehensive checking with type-aware ESLint rules
 - **Runtime Validation** - Zod schemas for all environment variables and request inputs
 - **Import Graph Validation** - dependency-cruiser prevents circular dependencies and enforces architecture
-- **Comprehensive Testing** - Unit, integration tests with 99.04% mutation testing score
+- **Comprehensive Testing** - Unit, integration tests with high-standard mutation testing
 
 ### Security First (Implemented)
 
@@ -301,7 +301,7 @@ This template is in **active development**. Current state:
 ✅ **Quality Tooling Complete**
 
 - dependency-cruiser for architectural validation
-- Mutation testing with Stryker (99.04% score)
+- Mutation testing with Stryker for test quality validation
 - Zod validation patterns for environment and inputs
 - Comprehensive testing framework with Vitest
 - CI/CD pipeline with GitHub Actions

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -151,7 +151,7 @@ pnpm ai:compliance  # Full quality pipeline (required before PR)
 pnpm lint           # ESLint + Prettier formatting
 pnpm type-check     # TypeScript strict compilation
 pnpm test           # Unit and integration tests (Vitest)
-pnpm test:mutation  # Mutation testing (Stryker) - 99.04% score
+pnpm test:mutation  # Mutation testing (Stryker) - high-quality standards
 pnpm graph:validate # Architecture dependency validation
 pnpm build          # Production build verification
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -416,7 +416,7 @@ pnpm ai:compliance  # Full quality pipeline including mutation testing
 pnpm lint           # ESLint + Prettier formatting
 pnpm type-check     # TypeScript strict compilation
 pnpm test           # Unit and integration tests (Vitest)
-pnpm test:mutation  # Mutation testing (Stryker) - 99.04% score
+pnpm test:mutation  # Mutation testing (Stryker) - high-quality standards
 pnpm graph:validate # Dependency architecture validation
 pnpm build          # Production build verification
 ```


### PR DESCRIPTION
## Summary

Remove specific performance claims (99.04% mutation testing) from documentation and replace with capability-focused descriptions.

**Changes:**
- Replace "99.04%" claims with "high-quality standards" 
- Change "sub-5-second quality gates" to "fast quality gates optimized for AI"
- Focus on value proposition (having mutation testing infrastructure) rather than exact metrics

## Rationale

Specific performance metrics in documentation are:
- **Environment-dependent** - vary by hardware, project size, cache state
- **Brittle** - require constant maintenance as codebase evolves  
- **Misleading** - 99.04% appears to be aspirational rather than measured
- **Distracting** - shifts focus from capability to vanity metrics

## Value Proposition Improvement

**Before:** "99.04% mutation testing score" 
**After:** "Mutation testing with Stryker for test quality validation"

This highlights the real differentiator: having mutation testing infrastructure ready to use when most projects have none.

## Files Changed

- `README.md` - Updated main documentation
- `docs/CONTRIBUTING.md` - Updated contributing guidelines  
- `docs/DEVELOPMENT.md` - Updated development workflow

🤖 Generated with [Claude Code](https://claude.ai/code)